### PR TITLE
Add fields to detect profile field presence

### DIFF
--- a/form.go
+++ b/form.go
@@ -66,18 +66,22 @@ func parseUserFromForm(f url.Values) (User, []pair, []byte, error) {
 		case "first_name":
 			ps = append(ps, pair{"first_name", v})
 			tu.FirstName = v
+			tu.HasFirstName = true
 		case "last_name":
 			ps = append(ps, pair{"last_name", v})
 			tu.LastName = v
+			tu.HasLastName = true
 		case "username":
 			ps = append(ps, pair{"username", v})
 			tu.Username = v
+			tu.HasUsername = true
 		case "photo_url":
 			ps = append(ps, pair{"photo_url", v})
 			var err error
 			if tu.PhotoURL, err = url.Parse(v); err != nil {
 				return tu, nil, expectedMAC, err
 			}
+			tu.HasPhotoURL = true
 		case "auth_date":
 			ps = append(ps, pair{"auth_date", v})
 			// Fractional seconds are lost by this conversion.

--- a/form_test.go
+++ b/form_test.go
@@ -36,18 +36,35 @@ func TestConvertAndVerifyForm_WithValidCredentials(t *testing.T) {
 	if !time.Date(2017, time.December, 4, 0, 1, 18, 0, time.UTC).Equal(u.AuthDate) {
 		t.Errorf("auth date should be 2017-12-04T00:01:18Z, but was %v", u.AuthDate)
 	}
+
+	if !u.HasFirstName {
+		t.Error("first name should be present, but was missing")
+	}
 	if u.FirstName != "John 🕶" {
 		t.Errorf("first name should be John 🕶, but was %v", u.FirstName)
 	}
+
 	if u.ID != 12345678 {
 		t.Errorf("ID should be 12345678, but was %d", u.ID)
+	}
+
+	if !u.HasLastName {
+		t.Error("last name should be present, but was missing")
 	}
 	if u.LastName != "Smith" {
 		t.Errorf("last name should be Smith, but was %v", u.LastName)
 	}
+
+	if !u.HasPhotoURL {
+		t.Error("photo URL should be present, but was missing")
+	}
 	p := url.URL{Scheme: "https", Host: "t.me", Path: "/i/userpic/320/jsmith.jpg"}
 	if *u.PhotoURL != p {
 		t.Errorf("photo URL should be https://t.me/i/userpic/320/jsmith.jpg but was %v", u.PhotoURL)
+	}
+
+	if !u.HasUsername {
+		t.Error("username should be present, but was missing")
 	}
 	if u.Username != "jsmith" {
 		t.Errorf("username should be jsmith, but was %s", u.Username)
@@ -68,6 +85,24 @@ func TestConvertAndVerifyForm_WithoutHash(t *testing.T) {
 	}
 }
 
+func TestConvertAndVerifyForm_WithMultipleHashes(t *testing.T) {
+	_, err := ConvertAndVerifyForm(url.Values{
+		"auth_date":  {"1512345678"},
+		"first_name": {"John 🕶"},
+		"hash": {
+			"25409759c10beb29bd3f3fe1d16ee0605ac82eb2907d886e196d481371b91501",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		"id":        {"12345678"},
+		"last_name": {"Smith"},
+		"photo_url": {"https://t.me/i/userpic/320/jsmith.jpg"},
+		"username":  {"jsmith"},
+	}, testBotToken)
+	if err == nil {
+		t.Error("expected validation error, but no error occurred")
+	}
+}
+
 func TestConvertAndVerifyForm_WithIncorrectHash(t *testing.T) {
 	_, err := ConvertAndVerifyForm(url.Values{
 		"auth_date":  {"1512345678"},
@@ -80,5 +115,28 @@ func TestConvertAndVerifyForm_WithIncorrectHash(t *testing.T) {
 	}, testBotToken)
 	if err != ErrInvalidHash {
 		t.Errorf("expected ErrInvalidHash, but was %v", err)
+	}
+}
+
+func TestConvertAndVerifyForm_MarksMissingFields(t *testing.T) {
+	u, err := ConvertAndVerifyForm(url.Values{
+		"auth_date": {"1512345678"},
+		"id":        {"12345678"},
+		"hash":      {"180f7d26839de06e6ecb26148f181553d24e1c62153400da55ae31483ee62ad3"},
+	}, testBotToken)
+	if err != nil {
+		t.Errorf("failed to convert and verify: %v", err)
+	}
+	if u.HasFirstName {
+		t.Error("first name should be absent, but was present")
+	}
+	if u.HasLastName {
+		t.Error("last name should be absent, but was present")
+	}
+	if u.HasPhotoURL {
+		t.Error("photo URL should be absent, but was present")
+	}
+	if u.HasUsername {
+		t.Error("username should be absent, but was present")
 	}
 }

--- a/json.go
+++ b/json.go
@@ -84,20 +84,24 @@ func parseUserFromJSON(r io.Reader) (User, []pair, []byte, error) {
 			firstName := v.(string)
 			ps = append(ps, pair{"first_name", firstName})
 			tu.FirstName = firstName
+			tu.HasFirstName = true
 		case "last_name":
 			lastName := v.(string)
 			ps = append(ps, pair{"last_name", lastName})
 			tu.LastName = lastName
+			tu.HasLastName = true
 		case "username":
 			username := v.(string)
 			ps = append(ps, pair{"username", username})
 			tu.Username = username
+			tu.HasUsername = true
 		case "photo_url":
 			photoURL := v.(string)
 			ps = append(ps, pair{"photo_url", photoURL})
 			if tu.PhotoURL, err = url.Parse(photoURL); err != nil {
 				return tu, nil, expectedMAC, err
 			}
+			tu.HasPhotoURL = true
 		case "auth_date":
 			authDate := v.(json.Number)
 			ps = append(ps, pair{"auth_date", authDate.String()})

--- a/json_test.go
+++ b/json_test.go
@@ -25,7 +25,7 @@ func TestConvertAndVerifyJSON_WithValidCredentials(t *testing.T) {
 	u, err := ConvertAndVerifyJSON(strings.NewReader(`{
 		"auth_date": 1512345678,
 		"first_name": "John 🕶",
-        "hash": "25409759c10beb29bd3f3fe1d16ee0605ac82eb2907d886e196d481371b91501",
+		"hash": "25409759c10beb29bd3f3fe1d16ee0605ac82eb2907d886e196d481371b91501",
 		"id": 12345678,
 		"last_name": "Smith",
 		"photo_url": "https://t.me/i/userpic/320/jsmith.jpg",
@@ -37,18 +37,35 @@ func TestConvertAndVerifyJSON_WithValidCredentials(t *testing.T) {
 	if !time.Date(2017, time.December, 4, 0, 1, 18, 0, time.UTC).Equal(u.AuthDate) {
 		t.Errorf("auth date should be 2017-12-04T00:01:18Z, but was %v", u.AuthDate)
 	}
+
+	if !u.HasFirstName {
+		t.Error("first name should be present, but was missing")
+	}
 	if u.FirstName != "John 🕶" {
 		t.Errorf("first name should be John 🕶, but was %v", u.FirstName)
 	}
+
 	if u.ID != 12345678 {
 		t.Errorf("ID should be 12345678, but was %d", u.ID)
+	}
+
+	if !u.HasLastName {
+		t.Error("last name should be present, but was missing")
 	}
 	if u.LastName != "Smith" {
 		t.Errorf("last name should be Smith, but was %v", u.LastName)
 	}
+
+	if !u.HasPhotoURL {
+		t.Error("photo URL should be present, but was missing")
+	}
 	p := url.URL{Scheme: "https", Host: "t.me", Path: "/i/userpic/320/jsmith.jpg"}
 	if *u.PhotoURL != p {
 		t.Errorf("photo URL should be https://t.me/i/userpic/320/jsmith.jpg but was %v", u.PhotoURL)
+	}
+
+	if !u.HasUsername {
+		t.Error("username should be present, but was missing")
 	}
 	if u.Username != "jsmith" {
 		t.Errorf("username should be jsmith, but was %s", u.Username)
@@ -73,7 +90,7 @@ func TestConvertAndVerifyJSON_WithIncorrectHash(t *testing.T) {
 	_, err := ConvertAndVerifyJSON(strings.NewReader(`{
 		"auth_date": 1512345678,
 		"first_name": "John 🕶",
-        "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+		"hash": "0000000000000000000000000000000000000000000000000000000000000000",
 		"id": 12345678,
 		"last_name": "Smith",
 		"photo_url": "https://t.me/i/userpic/320/jsmith.jpg",
@@ -120,5 +137,28 @@ func TestConvertAndVerifyJSON_WithEmptyString(t *testing.T) {
 	_, err := ConvertAndVerifyJSON(strings.NewReader(""), testBotToken)
 	if err == nil {
 		t.Errorf("should have returned error, but was nil")
+	}
+}
+
+func TestConvertAndVerifyJSON_MarksMissingFields(t *testing.T) {
+	u, err := ConvertAndVerifyJSON(strings.NewReader(`{
+		"auth_date": 1512345678,
+		"id": 12345678,
+		"hash": "180f7d26839de06e6ecb26148f181553d24e1c62153400da55ae31483ee62ad3"
+	}`), testBotToken)
+	if err != nil {
+		t.Errorf("failed to convert and verify: %v", err)
+	}
+	if u.HasFirstName {
+		t.Error("first name should be absent, but was present")
+	}
+	if u.HasLastName {
+		t.Error("last name should be absent, but was present")
+	}
+	if u.HasPhotoURL {
+		t.Error("photo URL should be absent, but was present")
+	}
+	if u.HasUsername {
+		t.Error("username should be absent, but was present")
 	}
 }

--- a/user.go
+++ b/user.go
@@ -19,12 +19,17 @@ import (
 	"time"
 )
 
-// A User is a Telegram user. All of the data returned from the Telegram login widget is represented in this type.
+// A User is a Telegram user. All of the data returned from the Telegram login
+// widget is represented in this type.
 type User struct {
-	AuthDate  time.Time
-	FirstName string
-	ID        int64
-	LastName  string
-	PhotoURL  *url.URL
-	Username  string
+	AuthDate     time.Time
+	FirstName    string
+	HasFirstName bool
+	ID           int64
+	LastName     string
+	HasLastName  bool
+	PhotoURL     *url.URL
+	HasPhotoURL  bool
+	Username     string
+	HasUsername  bool
 }


### PR DESCRIPTION
Previously, any field not set by the server would have its corresponding
value in User set to its zero value. This is probably okay: an empty
string as a photo URL or username is almost certainly invalid.

Even so, it's nice to be able to know for sure which fields were omitted
and which ones had an explicit zero value. To accomplish this, this
change adds Has* fields to User when the distinction is important.